### PR TITLE
Implementation of Warp Theme Generator 

### DIFF
--- a/cli/packages/warp/.gitignore
+++ b/cli/packages/warp/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+LICENSE.md

--- a/cli/packages/warp/.yarnrc
+++ b/cli/packages/warp/.yarnrc
@@ -1,0 +1,2 @@
+version-tag-prefix "@themerdev/warp-v"
+version-git-message "@themerdev/warp-v%s"

--- a/cli/packages/warp/README.md
+++ b/cli/packages/warp/README.md
@@ -1,0 +1,15 @@
+# @themerdev/warp
+
+A [Warp](https://warp.dev) theme generator for [themer](https://github.com/themerdev/themer).
+
+## Installation & usage
+
+Install this module wherever you have `themer` installed:
+
+    npm install @themerdev/warp
+
+Then pass `@themerdev/warp` as a `-t` (`--template`) arg to `themer`:
+
+    themer -c my-colors.js -t @themerdev/warp -o gen
+
+Installation instructions for the generated theme(s) will be included in `<output dir>/README.md`.

--- a/cli/packages/warp/lib/__snapshots__/index.spec.js.snap
+++ b/cli/packages/warp/lib/__snapshots__/index.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderInstructions should provide installation instructions 1`] = `
+"
+1. Copy your files (\`themer_colors-default_dark.yaml\` and \`themer_colors-default_light.yaml\`) to \`~/.warp/themes/\`
+2. Launch Warp
+3. Press \`command\`-\`P\` to open the Command Palette
+4. Search and select \`Open Theme Picker\`
+5. Search for \`Themer Colors Default Dark\` or \`Themer Colors Default Light\` and select it
+6. Enjoy your new theme! ✨
+"
+`;

--- a/cli/packages/warp/lib/index.js
+++ b/cli/packages/warp/lib/index.js
@@ -1,0 +1,109 @@
+const title = require('title');
+const WARP_TEMPLATE = `accent: "%ACCENT%"
+background: "%BACKGROUND%"
+foreground: "%FOREGROUND%"
+details: "%DETAILS%"
+terminal_colors:
+  normal:
+    black: "%N_BLACK%"
+    red: "%N_RED%"
+    green: "%N_GREEN%"
+    yellow: "%N_YELLOW%"
+    blue: "%N_BLUE%"
+    magenta: "%N_MAGENTA%"
+    cyan: "%N_CYAN%"
+    white: "%N_WHITE%"
+  bright:
+    black: "%B_BLACK%"
+    red: "%B_RED%"
+    green: "%B_GREEN%"
+    yellow: "%B_YELLOW%"
+    blue: "%B_BLUE%"
+    magenta: "%B_MAGENTA%"
+    cyan: "%B_CYAN%"
+    white: "%B_WHITE%"
+`;
+
+const render = (colors, options) => {
+  return [
+    { name: 'dark', colors: colors.dark },
+    { name: 'light', colors: colors.light },
+  ]
+    .filter((colorSet) => !!colorSet.colors)
+    .map((colorSet) => {
+      return Promise.resolve({
+        name: `themer_${options.colors.replace('./', '')}_${
+          colorSet.name
+        }.yaml`,
+        contents: Buffer.from(
+          WARP_TEMPLATE.replace('%ACCENT%', colorSet.colors.accent6)
+            .replace('%BACKGROUND%', colorSet.colors.shade0)
+            .replace('%FOREGROUND%', colorSet.colors.shade7)
+            .replace('%DETAILS%', `${colorSet.name}er`)
+            .replace(
+              '%N_BLACK%',
+              colorSet.name === 'dark'
+                ? colorSet.colors.shade0
+                : colorSet.colors.shade7,
+            )
+            .replace('%N_RED%', colorSet.colors.accent0)
+            .replace('%N_GREEN%', colorSet.colors.accent3)
+            .replace('%N_YELLOW%', colorSet.colors.accent2)
+            .replace('%N_BLUE%', colorSet.colors.accent5)
+            .replace('%N_MAGENTA%', colorSet.colors.accent7)
+            .replace('%N_CYAN%', colorSet.colors.accent4)
+            .replace(
+              '%N_WHITE%',
+              colorSet.name === 'dark'
+                ? colorSet.colors.shade6
+                : colorSet.colors.shade1,
+            )
+            .replace(
+              '%B_BLACK%',
+              colorSet.name === 'dark'
+                ? colorSet.colors.shade1
+                : colorSet.colors.shade6,
+            )
+            .replace('%B_RED%', colorSet.colors.accent1)
+            .replace('%B_GREEN%', colorSet.colors.accent4)
+            .replace('%B_YELLOW%', colorSet.colors.accent2)
+            .replace('%B_BLUE%', colorSet.colors.accent5)
+            .replace('%B_MAGENTA%', colorSet.colors.accent7)
+            .replace('%B_CYAN%', colorSet.colors.accent4)
+            .replace(
+              '%B_WHITE%',
+              colorSet.name === 'dark'
+                ? colorSet.colors.shade7
+                : colorSet.colors.shade0,
+            ),
+        ),
+      });
+    });
+};
+
+const renderInstructions = (paths) => `
+1. Copy your files (${paths
+  .map((p) => `\`${p}\``)
+  .join(' and ')}) to \`~/.warp/themes/\`
+2. Launch Warp
+3. Press \`command\`-\`P\` to open the Command Palette
+4. Search and select \`Open Theme Picker\`
+5. Search for ${paths
+  .map(
+    (p) =>
+      `\`${title(
+        p
+          .replace('warp/', '')
+          .replace('.yaml', '')
+          .replaceAll('-', ' ')
+          .replaceAll('_', ' '),
+      )}\``,
+  )
+  .join(' or ')} and select it
+6. Enjoy your new theme! ✨
+`;
+
+module.exports = {
+  render,
+  renderInstructions,
+};

--- a/cli/packages/warp/lib/index.spec.js
+++ b/cli/packages/warp/lib/index.spec.js
@@ -1,0 +1,49 @@
+const { render, renderInstructions } = require('./index');
+const { colors } = require('../../colors-default');
+
+describe('render', () => {
+  const promisedFiles = Promise.all(
+    render(colors, {
+      _: [],
+      c: './colors-default',
+      colors: './colors-default',
+      t: './warp',
+      template: ['./warp'],
+      o: '/tmp/themer',
+      out: '/tmp/themer',
+    }),
+  );
+
+  it('should render the expected number of files', async () => {
+    const files = await promisedFiles;
+    expect(files.length).toBe(2);
+  });
+
+  it('should render valid Warp theme yaml', async () => {
+    const files = await promisedFiles;
+    files.forEach((file) => {
+      const contents = file.contents.toString('utf8');
+      expect(
+        /([ ]+)?((\\w+|[^\\w\\s\\r\\n])([ ]*))?(?:\\r)?(\\n)?/.test(contents),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('renderInstructions', () => {
+  it('should provide installation instructions', async () => {
+    const files = await Promise.all(
+      render(colors, {
+        _: [],
+        c: './colors-default',
+        colors: './colors-default',
+        t: './warp',
+        template: ['./warp'],
+        o: '/tmp/themer',
+        out: '/tmp/themer',
+      }),
+    );
+    const instructions = renderInstructions(files.map(({ name }) => name));
+    expect(instructions).toMatchSnapshot();
+  });
+});

--- a/cli/packages/warp/package.json
+++ b/cli/packages/warp/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@themerdev/warp",
+  "version": "1.0.0",
+  "description": "Warp theme generator for themer.",
+  "main": "lib/index.js",
+  "engines": {
+    "node": ">=8.11.4"
+  },
+  "scripts": {
+    "prepublishOnly": "cp ../../../LICENSE.md ./"
+  },
+  "author": {
+    "name": "Torben Haack",
+    "email": "haack.t@icloud.com"
+  },
+  "license": "MIT",
+  "files": [
+    "/lib/index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/themerdev/themer.git"
+  },
+  "bugs": {
+    "url": "https://github.com/themerdev/themer/issues"
+  },
+  "homepage": "https://github.com/themerdev/themer/tree/main/cli/packages/warp#readme",
+  "peerDependencies": {
+    "themer": "^3"
+  },
+  "keywords": [
+    "themer",
+    "warp",
+    "warpterm",
+    "warp.dev",
+    "theme"
+  ],
+  "dependencies": {
+    "title": "^3.5.2"
+  },
+  "devDependencies": {}
+}

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -684,7 +684,7 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.1.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -716,6 +716,11 @@ aproba@^1.0.3:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
+arch@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
+  integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
+
 are-we-there-yet@~1.1.2:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
@@ -723,6 +728,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-1.0.0.tgz#444d885a4e25b121640b55155ef7cd03975d6050"
+  integrity sha512-Wk7TEzl1KqvTGs/uyhmHO/3XLd3t1UeU4IstvPXVzGPM522cTjqjNZ99esCkcL52sjqjo8e8CTBcWhkxvGzoAw==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -897,6 +907,15 @@ canvas@^2.6.1:
     nan "^2.14.0"
     simple-get "^3.0.3"
 
+chalk@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  integrity sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -940,6 +959,14 @@ cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
+
+clipboardy@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.2.tgz#2ce320b9ed9be1514f79878b53ff9765420903e2"
+  integrity sha512-16KrBOV7bHmHdxcQiCvfUFYVFyEah4FI8vYT1Fr7CGSA4G+xBWMEfUEQJS1hxeHGtI9ju1Bzs9uXSbj5HZKArw==
+  dependencies:
+    arch "^2.1.0"
+    execa "^0.8.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -1072,6 +1099,15 @@ cross-env@^6.0.3:
   integrity sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
   dependencies:
     cross-spawn "^7.0.0"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -1299,6 +1335,19 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha512-zDWS+Rb1E8BlqqhALSt9kUhss8Qq4nN3iof3gsOdyINksElaPyNBtKUMTR62qhvgVWR0CqCX7sdnKe4MnUbFEA==
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -1423,6 +1472,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==
+
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
@@ -1449,6 +1503,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  integrity sha512-P+1n3MnwjR/Epg9BBo1KT8qbye2g2Ou4sFumihwt6I4tsUX7jnLcX4BTOSKg/B1ZrIYMN9FcEnG4x5a7NB8Eng==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1599,6 +1658,11 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -2207,6 +2271,14 @@ lodash@^4.17.15, lodash@^4.17.4, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
@@ -2401,6 +2473,13 @@ nova-colors@^2.1.5:
   resolved "https://registry.yarnpkg.com/nova-colors/-/nova-colors-2.1.5.tgz#9d03da38e8b69b07aced888e4d9a44800caa5644"
   integrity sha1-nQPaOOi2mwes7YiOTZpEgAyqVkQ=
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  integrity sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==
+  dependencies:
+    path-key "^2.0.0"
+
 npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
@@ -2469,6 +2548,11 @@ p-each-series@^2.1.0:
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
   integrity sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -2507,6 +2591,11 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -2587,6 +2676,11 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.33:
   version "1.8.0"
@@ -2709,12 +2803,24 @@ set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -2859,10 +2965,22 @@ strip-bom@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+  integrity sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  integrity sha512-ycQR/UbvI9xIlEdQT1TQqwoXtEldExbCEAJgRo5YXlmSKjv6ThHnP9/vwGa1gr19Gfw+LkFd7KqYMhzrRC5JYw==
+  dependencies:
+    has-flag "^2.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -2931,6 +3049,21 @@ throat@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
   integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
+
+title@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/title/-/title-3.5.2.tgz#21596db334a55239d93b68525315b12da09624a9"
+  integrity sha512-PD9x2repsKvhDr/aE8mz9JlcyGKbTPOhIRraioVi9gc8AZEVok875UPFnWHFs97ddIomPC/oThpENPx3HhV5kg==
+  dependencies:
+    arg "1.0.0"
+    chalk "2.3.0"
+    clipboardy "1.2.2"
+    titleize "1.0.0"
+
+titleize@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/titleize/-/titleize-1.0.0.tgz#7d350722061830ba6617631e0cfd3ea08398d95a"
+  integrity sha512-TARUb7z1pGvlLxgPk++7wJ6aycXF3GJ0sNSBTAsTuJrQG5QuZlkUQP+zl+nbjAh4gMX9yDw9ZYklMd7vAfJKEw==
 
 tmpl@1.0.x:
   version "1.0.5"
@@ -3104,6 +3237,13 @@ whatwg-url@^8.0.0, whatwg-url@^8.5.0:
     tr46 "^2.1.0"
     webidl-conversions "^6.1.0"
 
+which@^1.2.9:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -3176,6 +3316,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This pull requests implements a theme generator for [Warp](https://warp.dev) based on the [Slack implementation](https://github.com/themerdev/themer/tree/main/cli/packages/slack).

### Generated Files

Two files will be generated, one for a light and one for a dark theme.
Theme Files will be generated in the following format: `themer_(Theme Name)_(dark | light).yaml`
e.g. `themer_colors-default_dark.yaml`

### Example File Output with `colors-default`

<img width="1653" alt="Screenshot of themer_colors-default_dark.yaml" src="https://user-images.githubusercontent.com/53407297/184537044-61b1806e-eb43-4d89-bd49-2ecd44c0bfba.png">

[(Permalink of output)](https://app.warp.dev/block/4gPwkwQcwWzK5YD0oJGuIL)

### Tests

<img width="1652" alt="Theme generator tested" src="https://user-images.githubusercontent.com/53407297/184537298-dd9fa7de-1810-4643-8225-54cc1a1c4856.png">

[(Permalink of output)](https://app.warp.dev/block/cOoB1yx53rnPRJSc2XXdxi)

###  `colors-default` applied to Application
<img width="1792" alt="Bildschirmfoto 2022-08-14 um 14 36 56" src="https://user-images.githubusercontent.com/53407297/184537163-a11b39ef-1d8e-4045-b3fb-c6b3d3b3b8ad.png">

