### PR TITLE
Remove references to Atom source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,8 +346,6 @@ export default template;
 
 ### Editors/IDEs
 
-- [`atom-syntax`](https://github.com/themerdev/themer/tree/main/cli/src/template/atom-syntax.ts)
-- [`atom-ui`](https://github.com/themerdev/themer/tree/main/cli/src/template/atom-ui.ts)
 - [`bbedit`](https://github.com/themerdev/themer/tree/main/cli/src/template/bbedit.ts)
 - [`emacs`](https://github.com/themerdev/themer/tree/main/cli/src/template/emacs.ts)
 - [`sublime-text`](https://github.com/themerdev/themer/tree/main/cli/src/template/sublime-text.ts)


### PR DESCRIPTION
This removes references to Atom files that no longer exist (presumably because Atom is an EOL'd Editor with no support or updates)
